### PR TITLE
Fix explicit screenshot utility imports

### DIFF
--- a/screenshots.py
+++ b/screenshots.py
@@ -4,9 +4,10 @@ import glob
 import os
 from pathlib import Path
 
+import cv2
 from PIL import Image
 
-from utils.utils import *
+from utils.utils import resize_image
 
 # directory of images to resize
 dir = "/Users/glennjocher/Downloads/"
@@ -29,12 +30,16 @@ def main():
         print(image)
 
         for i, format in enumerate(formats):
-            img_resized = resize_image(img, height=size_y[i], width=size_x[i], mode="Fill")  # i.e. mode = 'Pad'
+            img_resized = resize_image(
+                img, height=size_y[i], width=size_x[i], mode="Fill"
+            )  # i.e. mode = 'Pad'
 
             new_name = dir + new_dir + "/" + format + "_" + image.split("/")[-1]
 
             # cv2.imwrite(new_name.replace('.PNG', '.jpg').replace('.png', '.jpg'), img_resized)  # cv2 save
-            Image.fromarray(img_resized[..., ::-1]).save(new_name.replace(Path(new_name).suffix, ".jpg"))  # PIL save
+            Image.fromarray(img_resized[..., ::-1]).save(
+                new_name.replace(Path(new_name).suffix, ".jpg")
+            )  # PIL save
 
 
 if __name__ == "__main__":

--- a/screenshots.py
+++ b/screenshots.py
@@ -30,16 +30,12 @@ def main():
         print(image)
 
         for i, format in enumerate(formats):
-            img_resized = resize_image(
-                img, height=size_y[i], width=size_x[i], mode="Fill"
-            )  # i.e. mode = 'Pad'
+            img_resized = resize_image(img, height=size_y[i], width=size_x[i], mode="Fill")  # i.e. mode = 'Pad'
 
             new_name = dir + new_dir + "/" + format + "_" + image.split("/")[-1]
 
             # cv2.imwrite(new_name.replace('.PNG', '.jpg').replace('.png', '.jpg'), img_resized)  # cv2 save
-            Image.fromarray(img_resized[..., ::-1]).save(
-                new_name.replace(Path(new_name).suffix, ".jpg")
-            )  # PIL save
+            Image.fromarray(img_resized[..., ::-1]).save(new_name.replace(Path(new_name).suffix, ".jpg"))  # PIL save
 
 
 if __name__ == "__main__":

--- a/square.py
+++ b/square.py
@@ -28,9 +28,7 @@ def main():
         print(image)
 
         for i, format in enumerate(formats):
-            img_resized = resize_image(
-                img, height=size_y[i], width=size_x[i], mode="Fill"
-            )
+            img_resized = resize_image(img, height=size_y[i], width=size_x[i], mode="Fill")
             cv2.imwrite(dir + new_dir + "/" + image.split("/")[-1], img_resized)
 
 

--- a/square.py
+++ b/square.py
@@ -3,7 +3,9 @@
 import glob
 import os
 
-from utils.utils import *
+import cv2
+
+from utils.utils import resize_image
 
 # directory of images to resize
 dir = "/Users/glennjocher/downloads/app/styles/"
@@ -26,7 +28,9 @@ def main():
         print(image)
 
         for i, format in enumerate(formats):
-            img_resized = resize_image(img, height=size_y[i], width=size_x[i], mode="Fill")
+            img_resized = resize_image(
+                img, height=size_y[i], width=size_x[i], mode="Fill"
+            )
             cv2.imwrite(dir + new_dir + "/" + image.split("/")[-1], img_resized)
 
 


### PR DESCRIPTION
## Summary
- replace wildcard screenshot utility imports with explicit `cv2` and `resize_image` imports
- keep screenshot resizing behavior unchanged while making definitions visible to Ruff

## Tests
- `ruff check screenshots.py square.py`
- `ruff format screenshots.py square.py`
- `python -m compileall screenshots.py square.py utils`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR cleans up image-processing scripts by replacing wildcard imports with a specific utility import and explicitly adding `cv2` where needed.

### 📊 Key Changes
- Replaced `from utils.utils import *` with `from utils.utils import resize_image` in `screenshots.py` and `square.py`.
- Added explicit `import cv2` to both files.
- Kept the scripts focused on the specific image-resizing utility they use, rather than importing everything from the utilities module.

### 🎯 Purpose & Impact
- ✅ Improves code clarity by making dependencies more obvious.
- ✅ Reduces the risks that come with wildcard imports, such as hidden name conflicts or harder-to-read code.
- ✅ Makes maintenance easier for developers by showing exactly which utility function each script depends on.
- 🔧 Likely has little to no user-facing impact, but helps keep the repository cleaner and more reliable for future updates.